### PR TITLE
Add the (x*y)**a == ... formula

### DIFF
--- a/formulas/powers.py
+++ b/formulas/powers.py
@@ -6,7 +6,6 @@ def_Topic(
     Title("Powers"),
     Entries(
         "ef9f8a",
-        "2090c3",
     ),
     Section("Integer exponents"),
     Entries(
@@ -28,6 +27,10 @@ def_Topic(
         "bc4d0a",
         "caf8cf",
         "18873d",
+    ),
+    Section("Expansion"),
+    Entries(
+        "2090c3",
     ),
 )
 

--- a/formulas/powers.py
+++ b/formulas/powers.py
@@ -119,8 +119,8 @@ make_entry(ID("18873d"),
 make_entry(ID("2090c3"),
     Formula(Equal(
         Pow(Mul(x, y), a),
-        Mul(Mul(Pow(x, a), Pow(y, a)), Exp(2*pi*ConstI*a \
-            * Floor((pi-Arg(x)-Arg(y))/(2*pi))
+        Mul(Mul(Pow(x, a), Pow(y, a)), Exp(2*ConstPi*ConstI*a \
+            * Floor((ConstPi-Arg(x)-Arg(y))/(2*ConstPi))
         ))
     )),
     Variables(x, y, a),

--- a/formulas/powers.py
+++ b/formulas/powers.py
@@ -6,6 +6,7 @@ def_Topic(
     Title("Powers"),
     Entries(
         "ef9f8a",
+        "XX1111",
     ),
     Section("Integer exponents"),
     Entries(
@@ -113,6 +114,22 @@ make_entry(ID("18873d"),
         Where(M**c * Exp(-(d*theta)) * Sin(c*theta + d*Log(M)), Equal(M, Abs(a+b*ConstI)), Equal(theta, Arg(a+b*ConstI))))),
     Variables(a, b, c, d),
     Assumptions(And(Element(a, RR), Element(b, RR), Element(c, RR), Element(d, RR), Unequal(a+b*ConstI, 0))))
+
+
+make_entry(ID("XX1111"),
+    Formula(Equal(
+        Pow(Mul(x, y), a),
+        Mul(Mul(Pow(x, a), Pow(y, a)), Exp(2*pi*ConstI*a \
+            * Floor((pi-Arg(x)-Arg(y))/(2*pi))
+        ))
+    )),
+    Variables(x, y, a),
+    Assumptions(And(
+        Element(x, CC),
+        Element(y, CC),
+        Element(a, SetMinus(CC, Set(0)))
+    ))
+)
 
 
 """

--- a/formulas/powers.py
+++ b/formulas/powers.py
@@ -6,7 +6,7 @@ def_Topic(
     Title("Powers"),
     Entries(
         "ef9f8a",
-        "XX1111",
+        "2090c3",
     ),
     Section("Integer exponents"),
     Entries(
@@ -116,7 +116,7 @@ make_entry(ID("18873d"),
     Assumptions(And(Element(a, RR), Element(b, RR), Element(c, RR), Element(d, RR), Unequal(a+b*ConstI, 0))))
 
 
-make_entry(ID("XX1111"),
+make_entry(ID("2090c3"),
     Formula(Equal(
         Pow(Mul(x, y), a),
         Mul(Mul(Pow(x, a), Pow(y, a)), Exp(2*pi*ConstI*a \

--- a/formulas/powers.py
+++ b/formulas/powers.py
@@ -125,9 +125,9 @@ make_entry(ID("2090c3"),
     )),
     Variables(x, y, a),
     Assumptions(And(
-        Element(x, CC),
-        Element(y, CC),
-        Element(a, SetMinus(CC, Set(0)))
+        Element(x, SetMinus(CC, Set(0))),
+        Element(y, SetMinus(CC, Set(0))),
+        Element(a, CC)
     ))
 )
 


### PR DESCRIPTION
Two issues to be resolved:

* [x] Precise definition of Arg(z)
* [x] How is the hash obtained? Randomly? This needs to be changed

Note: this formula is only correct if Arg is defined precisely as `arg(z) = atan2(Im z, Re z)`, however, the Arg in Fungrim does not seem to be well defined (yet):

http://fungrim.org/entry/b7d740.html

so this needs to be settled first. Because if `arg(z)` is defined using some other branch cut, then the formula in this PR changes accordingly.