### PR TITLE
The (x*y)^a formula seems valid for x, y = 0 also

### DIFF
--- a/pygrim/formulas/powers.py
+++ b/pygrim/formulas/powers.py
@@ -128,8 +128,8 @@ make_entry(ID("2090c3"),
     )),
     Variables(x, y, a),
     Assumptions(And(
-        Element(x, SetMinus(CC, Set(0))),
-        Element(y, SetMinus(CC, Set(0))),
+        Element(x, CC),
+        Element(y, CC),
         Element(a, CC)
     ))
 )


### PR DESCRIPTION
It's this formula: http://fungrim.org/entry/2090c3/, it seems it's valid even if `x` and/or `y` are 0.